### PR TITLE
fix bad assertion

### DIFF
--- a/src/com/keminglabs/zmq_async/core.clj
+++ b/src/com/keminglabs/zmq_async/core.clj
@@ -275,8 +275,13 @@ Accepts a map with the following keys:
   (when (and socket (or socket-type configurator))
     (throw (IllegalArgumentException. "You can provide a ZeroMQ socket OR a socket-type and configurator, not both.")))
 
-  (when (and (nil? out) (nil? in))
-    (throw (IllegalArgumentException. "You must provide at least one of :out and :in channels.")))
+  (cond
+    (#{:pair :req :rep :xreq :xrep :dealer :router :xpub :xsub} socket-type)
+    (assert (and in out) (str socket-type "socket requires both :in and :out channels"))
+    (#{:pub :push} socket-type)
+    (assert in (str socket-type "socket requires an :in channel"))
+    (#{:sub :pull} socket-type)
+    (assert out (str socket-type "socket requires an :out channel")))
 
   (let [context (or context (doto automagic-context
                               (initialize!)))

--- a/src/com/keminglabs/zmq_async/core.clj
+++ b/src/com/keminglabs/zmq_async/core.clj
@@ -157,9 +157,9 @@ Sends messages to complementary `zmq-looper` via provided `zmq-control-sock` (as
           ;;Relay a message from ZeroMQ socket to core.async channel.
           [:control [sock-id msg]]
           (let [out (get-in pairings [sock-id :out])]
-            (assert out)
-            ;;We have a contract with library consumers that they cannot give us channels that can block, so this >!! won't tie up the async looper.
-            (>!! out msg)
+            (when out
+              ;;We have a contract with library consumers that they cannot give us channels that can block, so this >!! won't tie up the async looper.
+              (>!! out msg))
             (recur pairings))
 
           ;;The control channel has been closed, close all ZMQ sockets and channels.


### PR DESCRIPTION
[This assertion](https://github.com/lynaghk/zmq-async/blob/69ff7682d38ed964d84a7471a3b51e5492067bc3/src/com/keminglabs/zmq_async/core.clj#L160) will fail under legitimate circumstances.

Consider the following sequence of events:
1. A pull socket is registered
2. Async loop has the socket in the pairings map
3. ZMQ loop has the socket in the socks map
4. The in channel of the socket is closed, and at the same time a message is received from the ZMQ socket
5. Async loop will dissoc the socket from the pairings map
6. ZMQ loop will relay the message to the async loop
7. Async loop will look up the socket from the pairings map, but the socket in question has already been dissoc'ed
8. An exception is thrown, after which nothing works anymore.
